### PR TITLE
make more methods and constructors public to walk schema

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/processors/validation/ArraySchemaDigester.java
+++ b/src/main/java/com/github/fge/jsonschema/processors/validation/ArraySchemaDigester.java
@@ -31,7 +31,7 @@ public final class ArraySchemaDigester
 {
     private static final Digester INSTANCE = new ArraySchemaDigester();
 
-    static Digester getInstance()
+    public static Digester getInstance()
     {
         return INSTANCE;
     }

--- a/src/main/java/com/github/fge/jsonschema/processors/validation/ArraySchemaSelector.java
+++ b/src/main/java/com/github/fge/jsonschema/processors/validation/ArraySchemaSelector.java
@@ -43,7 +43,7 @@ public final class ArraySchemaSelector
     private final int itemsSize;
     private final boolean hasAdditional;
 
-    ArraySchemaSelector(final JsonNode digest)
+    public ArraySchemaSelector(final JsonNode digest)
     {
         hasItems = digest.get("hasItems").booleanValue();
         itemsIsArray = digest.get("itemsIsArray").booleanValue();
@@ -51,7 +51,7 @@ public final class ArraySchemaSelector
         hasAdditional = digest.get("hasAdditional").booleanValue();
     }
 
-    Iterable<JsonPointer> selectSchemas(final int index)
+    public Iterable<JsonPointer> selectSchemas(final int index)
     {
         if (!hasItems)
             return hasAdditional

--- a/src/main/java/com/github/fge/jsonschema/processors/validation/ObjectSchemaSelector.java
+++ b/src/main/java/com/github/fge/jsonschema/processors/validation/ObjectSchemaSelector.java
@@ -46,7 +46,7 @@ public final class ObjectSchemaSelector
     private final List<String> patternProperties;
     private final boolean hasAdditional;
 
-    ObjectSchemaSelector(final JsonNode digest)
+    public ObjectSchemaSelector(final JsonNode digest)
     {
         hasAdditional = digest.get("hasAdditional").booleanValue();
 
@@ -63,7 +63,7 @@ public final class ObjectSchemaSelector
         patternProperties = ImmutableList.copyOf(list);
     }
 
-    Iterable<JsonPointer> selectSchemas(final String memberName)
+    public Iterable<JsonPointer> selectSchemas(final String memberName)
     {
         final List<JsonPointer> list = Lists.newArrayList();
 


### PR DESCRIPTION
This is a pull request to make all the methods and constructors I needed public.  This should allow anyone to walk the schema and resolve references similar to the ValidationProcessor.
