### PR TITLE
Fix for issue 50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>json-schema-validator</artifactId>
     <name>json-schema-validator</name>
     <version>2.1.4-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <description>A Java implementation of the JSON Schema specification</description>
     <url>https://github.com/fge/json-schema-validator</url>
     <build>
@@ -74,6 +74,22 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <version>2.3.7</version>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            com.google.i18n.phonenumbers.*;resolution:=optional,
+                            javax.mail.internet.*;resolution:=optional,
+                            org.joda.time.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
https://github.com/fge/json-schema-validator/issues/50

I marked a few packages as optional because they are used in specific types of attributes that may not be used. If a system wants to use those types (like phone number) they can add the appropriate jars to their OSGi environment and be good to go.
