### PR TITLE
Added a lib jar to the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,11 +128,22 @@ task fullJar(type: OneJar) {
     archiveName = "jsonschema.jar";
 }
 
+/*
+ * Creates a jar that can be used as a library on java projects.
+ * This jar already includes all the dependencies.
+ */
+task libJar(type: Jar, dependsOn: jar) {
+    appendix = "lib"
+    from {configurations.compile.collect {zipTree(it)}}
+    with jar
+}
+
 artifacts {
     archives jar;
     archives sourcesJar;
     archives javadocJar;
     archives fullJar;
+    archives libJar;
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
With this change, a new jar will be created during the build. This jar includes all the dependencies of the validator, so it is the only jar needed to use the json-schema-validator API in a java project.
