### PR TITLE
Upgraded libphonenumber dependency from 6.0 to 6.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     compile(group: "javax.mail", name: "mailapi", version: "1.4.3");
     compile(group: "joda-time", name: "joda-time", version: "2.3");
     compile(group: "com.googlecode.libphonenumber", name: "libphonenumber",
-        version: "6.0");
+        version: "6.2");
     compile(group: "com.google.code.findbugs", name: "jsr305",
         version: "2.0.1");
     compile(group: "net.sf.jopt-simple", name: "jopt-simple", version: "4.6");


### PR DESCRIPTION
This patch upgrades libphonenumber dependency from 6.0 to 6.2
