### PR TITLE
Add tests to document behavior of '.' in pattern validation

### DIFF
--- a/src/test/resources/keyword/special/pattern.json
+++ b/src/test/resources/keyword/special/pattern.json
@@ -10,6 +10,32 @@
         "valid": true
     },
     {
+      "schema": {"pattern": "^some.pattern$"},
+      "data":"some_pattern",
+      "valid": true
+    },
+    {
+      "schema": {"pattern": "^some.pattern$"},
+      "data":"somePpattern",
+      "valid": true
+    },
+    {
+      "schema":{"pattern": "^some\\.pattern$"},
+      "data":"some.pattern",
+      "valid":true
+    },
+    {
+      "schema":{"pattern":"^some\\.pattern$"},
+      "data":"some_pattern",
+      "valid":false,
+      "message":"err.common.pattern.noMatch",
+      "msgData": {
+        "regex": "^some\\.pattern$",
+        "string": "some_pattern"
+      },
+      "msgParams": ["regex", "string"]
+    },
+    {
         "schema": { "pattern": "^[Aa]" },
         "data": "foobar",
         "valid": false,


### PR DESCRIPTION
The library treats "." as a wildcard even though the json validation spec is slightly ambiguous on certain regex special characters such as the period.  The expanded usage of the period as a wildcard is not in violation of the spec, but it could cause interop issues in the future, so additional documentation on its current behavior is being added via additional tests.
