### PR TITLE
Roll back to old date time validator

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/format/common/RFC3339DateTimeAttribute.java
+++ b/src/main/java/com/github/fge/jsonschema/format/common/RFC3339DateTimeAttribute.java
@@ -2,6 +2,8 @@ package com.github.fge.jsonschema.format.common;
 
 import java.util.List;
 
+import com.github.fge.jsonschema.cfg.ValidationConfiguration;
+import com.github.fge.jsonschema.library.DraftV4Library;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.DateTimeParser;
@@ -18,6 +20,13 @@ import com.google.common.collect.ImmutableList;
 /**
  * A {@link DateTimeFormatter} for date and time format defined in RFC3339.  
  * @see <a href="https://tools.ietf.org/html/rfc3339#section-5.6">RFC 3339 - Section 5.6</a>
+ *
+ * This is backwards incompat with the original DateTimeAttribute.  It will become the default in the future
+ * to use it currently you need to:
+ * Library library = DraftV4Library.get().thaw()
+ *     .addFormatAttribute("date-time", RFC3339DateTimeAttribute.getInstance())
+ *     .freeze();
+ * Then follow the rest of the steps in example 8 to hook it into your flow.
  */
 public class RFC3339DateTimeAttribute extends AbstractFormatAttribute {
 

--- a/src/main/java/com/github/fge/jsonschema/library/format/CommonFormatAttributesDictionary.java
+++ b/src/main/java/com/github/fge/jsonschema/library/format/CommonFormatAttributesDictionary.java
@@ -22,9 +22,9 @@ package com.github.fge.jsonschema.library.format;
 import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.core.util.DictionaryBuilder;
 import com.github.fge.jsonschema.format.FormatAttribute;
+import com.github.fge.jsonschema.format.common.DateTimeAttribute;
 import com.github.fge.jsonschema.format.common.EmailAttribute;
 import com.github.fge.jsonschema.format.common.IPv6Attribute;
-import com.github.fge.jsonschema.format.common.RFC3339DateTimeAttribute;
 import com.github.fge.jsonschema.format.common.RegexAttribute;
 import com.github.fge.jsonschema.format.common.URIAttribute;
 
@@ -49,7 +49,7 @@ public final class CommonFormatAttributesDictionary
         FormatAttribute attribute;
 
         name = "date-time";
-        attribute = RFC3339DateTimeAttribute.getInstance();
+        attribute = DateTimeAttribute.getInstance();
         builder.addEntry(name, attribute);
 
         name = "email";

--- a/src/test/java/com/github/fge/jsonschema/format/rfc3339/DateTimeTest.java
+++ b/src/test/java/com/github/fge/jsonschema/format/rfc3339/DateTimeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014, Francis Galiegue (fgaliegue@gmail.com)
+ *
+ * This software is dual-licensed under:
+ *
+ * - the Lesser General Public License (LGPL) version 3.0 or, at your option, any
+ *   later version;
+ * - the Apache Software License (ASL) version 2.0.
+ *
+ * The text of this file and of both licenses is available at the root of this
+ * project or, if you have the jar distribution, in directory META-INF/, under
+ * the names LGPL-3.0.txt and ASL-2.0.txt respectively.
+ *
+ * Direct link to the sources:
+ *
+ * - LGPL 3.0: https://www.gnu.org/licenses/lgpl-3.0.txt
+ * - ASL 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package com.github.fge.jsonschema.format.rfc3339;
+
+import com.github.fge.jsonschema.core.util.Dictionary;
+import com.github.fge.jsonschema.core.util.DictionaryBuilder;
+import com.github.fge.jsonschema.format.AbstractFormatAttributeTest;
+import com.github.fge.jsonschema.format.FormatAttribute;
+import com.github.fge.jsonschema.format.common.RFC3339DateTimeAttribute;
+
+import java.io.IOException;
+import java.text.Format;
+
+public final class DateTimeTest
+    extends AbstractFormatAttributeTest
+{
+    private static final Dictionary<FormatAttribute> dict =
+        Dictionary
+            .<FormatAttribute>newBuilder()
+            .addEntry("date-time", RFC3339DateTimeAttribute.getInstance())
+            .freeze();
+
+    public DateTimeTest()
+        throws IOException
+    {
+        super(dict, "rfc3339", "date-time");
+    }
+}

--- a/src/test/resources/format/common/date-time.json
+++ b/src/test/resources/format/common/date-time.json
@@ -1,6 +1,6 @@
 [
     {
-        "data": "2012-12-02T13:05:00+01:00",
+        "data": "2012-12-02T13:05:00+0100",
         "valid": true
     },
     {
@@ -20,12 +20,14 @@
         "valid": true
     },
     {
-        "data": "2012-08-07T20:42:32+10:00",
-        "valid": true
-    },    
-    {
-        "data": "2012-08-07T20:42:32-05:30",
-        "valid": true
+        "data": "2012-02-30T00:00:00+0000",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-02-30T00:00:00+0000",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}Z" ]
+        },
+        "msgParams": [ "value", "expected" ]
     },
     {
         "data": "201202030",
@@ -33,86 +35,12 @@
         "message": "err.format.invalidDate",
         "msgData": {
             "value": "201202030",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
-        },
-        "msgParams": [ "value", "expected" ]
-    },
-    {
-        "data": "2012-12-02T13:05:00+0100",
-        "valid": false,
-        "message": "err.format.invalidDate",
-        "msgData": {
-            "value": "2012-12-02T13:05:00+0100",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
-        },
-        "msgParams": [ "value", "expected" ]
-    },
-    {
-        "data": "2012-12-02T13:05:00+01:30:30",
-        "valid": false,
-        "message": "err.format.invalidDate",
-        "msgData": {
-            "value": "2012-12-02T13:05:00+01:30:30",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
-        },
-        "msgParams": [ "value", "expected" ]
-    },
-    {
-        "data": "2012-12-02T13:05:00Z[Europe/Paris]",
-        "valid": false,
-        "message": "err.format.invalidDate",
-        "msgData": {
-            "value": "2012-12-02T13:05:00Z[Europe/Paris]",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
-        },
-        "msgParams": [ "value", "expected" ]
-    }, 
-    {
-        "data": "2012-12-02T13:05:00+10:00Z",
-        "valid": false,
-        "message": "err.format.invalidDate",
-        "msgData": {
-            "value": "2012-12-02T13:05:00+10:00Z",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
-        },
-        "msgParams": [ "value", "expected" ]
-    },
-    {
-        "data": "2012-12-02T13:05:00America/New_York",
-        "valid": false,
-        "message": "err.format.invalidDate",
-        "msgData": {
-            "value": "2012-12-02T13:05:00America/New_York",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
-        },
-        "msgParams": [ "value", "expected" ]
-    },
-    {
-        "data": "2012-12-02T13:05:00[America/New_York]",
-        "valid": false,
-        "message": "err.format.invalidDate",
-        "msgData": {
-            "value": "2012-12-02T13:05:00[America/New_York]",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
-        },
-        "msgParams": [ "value", "expected" ]
-    },
-    {
-        "data": "2012-12-02T13:05:00.123456",
-        "valid": false,
-        "message": "err.format.invalidDate",
-        "msgData": {
-            "value": "2012-12-02T13:05:00.123456",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}Z" ]
         },
         "msgParams": [ "value", "expected" ]
     },
     {
       "data": "2012-08-07T20:42:32.1234Z",
-      "valid": true
-    },
-    {
-      "data": "2012-08-07T20:42:32.1234+05:00",
       "valid": true
     },
     {
@@ -125,6 +53,10 @@
     },
     {
       "data": "2012-08-07T20:42:32.1234567Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345678Z",
       "valid": true
     },
     {
@@ -145,10 +77,6 @@
     },
     {
       "data": "2012-08-07T20:42:32.123456789012Z",
-      "valid": true
-    },
-    {
-      "data": "2012-08-07T20:42:32.123456789012+05:00",
       "valid": true
     }
 ]

--- a/src/test/resources/format/rfc3339/date-time.json
+++ b/src/test/resources/format/rfc3339/date-time.json
@@ -1,0 +1,154 @@
+[
+    {
+        "data": "2012-12-02T13:05:00+01:00",
+        "valid": true
+    },
+    {
+        "data": "2001-02-12T00:00:00Z",
+        "valid": true
+    },
+    {
+        "data": "2012-08-07T20:42:32Z",
+        "valid": true
+    },
+    {
+        "data": "2012-08-07T20:42:32.123Z",
+        "valid": true
+    },
+    {
+        "data": "2012-08-07T20:42:32.13Z",
+        "valid": true
+    },
+    {
+        "data": "2012-08-07T20:42:32+10:00",
+        "valid": true
+    },    
+    {
+        "data": "2012-08-07T20:42:32-05:30",
+        "valid": true
+    },
+    {
+        "data": "201202030",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "201202030",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    },
+    {
+        "data": "2012-12-02T13:05:00+0100",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-12-02T13:05:00+0100",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    },
+    {
+        "data": "2012-12-02T13:05:00+01:30:30",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-12-02T13:05:00+01:30:30",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    },
+    {
+        "data": "2012-12-02T13:05:00Z[Europe/Paris]",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-12-02T13:05:00Z[Europe/Paris]",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    }, 
+    {
+        "data": "2012-12-02T13:05:00+10:00Z",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-12-02T13:05:00+10:00Z",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    },
+    {
+        "data": "2012-12-02T13:05:00America/New_York",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-12-02T13:05:00America/New_York",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    },
+    {
+        "data": "2012-12-02T13:05:00[America/New_York]",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-12-02T13:05:00[America/New_York]",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    },
+    {
+        "data": "2012-12-02T13:05:00.123456",
+        "valid": false,
+        "message": "err.format.invalidDate",
+        "msgData": {
+            "value": "2012-12-02T13:05:00.123456",
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ss((+|-)HH:mm|Z)", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}((+|-)HH:mm|Z)" ]
+        },
+        "msgParams": [ "value", "expected" ]
+    },
+    {
+      "data": "2012-08-07T20:42:32.1234Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.1234+05:00",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.123456Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.1234567Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345678Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.123456789Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.1234567890Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345678901Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.123456789012Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.123456789012+05:00",
+      "valid": true
+    }
+]


### PR DESCRIPTION
Allow people to still use the new formatter via the mechanism described
in example 8.

fixes #261