### PR TITLE
Upgrade Fest Assert to AssertJ.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,8 @@ dependencies {
         exclude(group: "org.yaml", module: "snakeyaml");
     };
     testCompile(group: "org.mockito", name: "mockito-core", version: "2.4.2");
-    testCompile(group: "org.easytesting", name: "fest-assert", version: "1.4");
+    // FIXME: update to 3.x once we're off of Java 7.
+    testCompile(group: "org.assertj", name: "assertj-core", version: "2.9.1");
 }
 
 javadoc {

--- a/src/test/java/com/github/fge/jsonschema/matchers/ProcessingMessageAssert.java
+++ b/src/test/java/com/github/fge/jsonschema/matchers/ProcessingMessageAssert.java
@@ -19,6 +19,7 @@
 
 package com.github.fge.jsonschema.matchers;
 
+import org.assertj.core.api.AbstractAssert;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -27,16 +28,15 @@ import com.github.fge.jsonschema.core.report.LogLevel;
 import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.tree.SchemaTree;
 import com.github.fge.jsonschema.core.util.AsJson;
-import org.fest.assertions.GenericAssert;
 
 import java.util.Collection;
 import java.util.Map;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.testng.Assert.*;
 
 public final class ProcessingMessageAssert
-    extends GenericAssert<ProcessingMessageAssert, ProcessingMessage>
+    extends AbstractAssert<ProcessingMessageAssert, ProcessingMessage>
 {
     private final JsonNode msg;
 
@@ -48,7 +48,7 @@ public final class ProcessingMessageAssert
 
     private ProcessingMessageAssert(final ProcessingMessage actual)
     {
-        super(ProcessingMessageAssert.class, actual);
+        super(actual, ProcessingMessageAssert.class);
         msg = actual.asJson();
     }
 
@@ -88,9 +88,10 @@ public final class ProcessingMessageAssert
         assertThat(msg.has(name)).isTrue();
         final String input = msg.get(name).textValue();
         final String expected = value.toString();
-        assertThat(input).isEqualTo(expected)
+        assertThat(input)
             .overridingErrorMessage("Strings differ: wanted " + expected
-                + " but got " + input);
+                + " but got " + input)
+            .isEqualTo(expected);
         return this;
     }
 


### PR DESCRIPTION
Also re-ordered one `overridingErrorMessage` to be applied before the assert evaluation.

Same fixes as for java-json-tools/json-schema-core/issues/66.