### PR TITLE
Prepare for 2.2.14.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -21,7 +21,7 @@
  * Project-specific settings. Unfortunately we cannot put the name in there!
  */
 group = "com.github.java-json-tools";
-version = "2.2.13";
+version = "2.2.14-SNAPSHOT";
 sourceCompatibility = JavaVersion.VERSION_1_7;
 targetCompatibility = JavaVersion.VERSION_1_7; // defaults to sourceCompatibility
 
@@ -34,7 +34,8 @@ project.ext {
  */
 dependencies {
     compile(group: "com.google.guava", name: "guava", version: "28.2-android");
-    compile(group: "com.github.java-json-tools", name: "json-schema-core", version: "1.2.13");
+    compile(group: "com.github.java-json-tools", name: "jackson-coreutils-equivalence", version: "1.0-SNAPSHOT");
+    compile(group: "com.github.java-json-tools", name: "json-schema-core", version: "1.2.14-SNAPSHOT");
     // FIXME: 1.6.4 exists, but has different license (EDL 1.0, EPL 2.0). Can update?
     compile(group: "com.sun.mail", name: "mailapi", version: "1.6.2");
     compile(group: "joda-time", name: "joda-time", version: "2.10.5");
@@ -60,8 +61,8 @@ javadoc {
         }
         links("https://docs.oracle.com/javase/7/docs/api/");
         links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.2/");
-        links("https://fasterxml.github.io/jackson-databind/javadoc/2.10/");
-        links("https://fasterxml.github.io/jackson-core/javadoc/2.10/");
+        links("https://fasterxml.github.io/jackson-databind/javadoc/2.11/");
+        links("https://fasterxml.github.io/jackson-core/javadoc/2.11/");
         links("https://www.javadoc.io/doc/com.google.guava/guava/28.2-android/");
         links("https://java-json-tools.github.io/btf/");
         links("https://java-json-tools.github.io/msg-simple/");

--- a/src/main/java/com/github/fge/jsonschema/keyword/validator/common/EnumValidator.java
+++ b/src/main/java/com/github/fge/jsonschema/keyword/validator/common/EnumValidator.java
@@ -20,7 +20,7 @@
 package com.github.fge.jsonschema.keyword.validator.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.processing.Processor;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
@@ -32,13 +32,13 @@ import com.google.common.base.Equivalence;
 /**
  * Keyword validator for {@code enum}
  *
- * @see JsonNumEquals
+ * @see JsonNumEquivalence
  */
 public final class EnumValidator
     extends AbstractKeywordValidator
 {
     private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+        = JsonNumEquivalence.getInstance();
 
     private final JsonNode values;
 

--- a/src/main/java/com/github/fge/jsonschema/keyword/validator/common/UniqueItemsValidator.java
+++ b/src/main/java/com/github/fge/jsonschema/keyword/validator/common/UniqueItemsValidator.java
@@ -20,7 +20,7 @@
 package com.github.fge.jsonschema.keyword.validator.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.processing.Processor;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
@@ -35,13 +35,13 @@ import java.util.Set;
 /**
  * Keyword validator for {@code uniqueItems}
  *
- * @see JsonNumEquals
+ * @see JsonNumEquivalence
  */
 public final class UniqueItemsValidator
     extends AbstractKeywordValidator
 {
     private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+        = JsonNumEquivalence.getInstance();
 
     private final boolean uniqueItems;
 

--- a/src/test/java/com/github/fge/jsonschema/keyword/digest/AbstractDigesterTest.java
+++ b/src/test/java/com/github/fge/jsonschema/keyword/digest/AbstractDigesterTest.java
@@ -21,7 +21,7 @@ package com.github.fge.jsonschema.keyword.digest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jsonschema.core.util.Dictionary;
 import com.google.common.base.Equivalence;
@@ -40,7 +40,7 @@ import static org.testng.Assert.*;
 public abstract class AbstractDigesterTest
 {
     private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+        = JsonNumEquivalence.getInstance();
 
     private final String keyword;
     private final Digester digester;

--- a/src/test/java/com/github/fge/jsonschema/processors/validation/ArraySchemaDigesterTest.java
+++ b/src/test/java/com/github/fge/jsonschema/processors/validation/ArraySchemaDigesterTest.java
@@ -21,7 +21,7 @@ package com.github.fge.jsonschema.processors.validation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jsonschema.keyword.digest.Digester;
 import com.google.common.base.Equivalence;
 import com.google.common.collect.Lists;
@@ -37,7 +37,7 @@ import static org.testng.Assert.*;
 public final class ArraySchemaDigesterTest
 {
     private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+        = JsonNumEquivalence.getInstance();
 
     private final Digester digester = ArraySchemaDigester.getInstance();
     private final JsonNode testNode;

--- a/src/test/java/com/github/fge/jsonschema/processors/validation/ObjectSchemaDigesterTest.java
+++ b/src/test/java/com/github/fge/jsonschema/processors/validation/ObjectSchemaDigesterTest.java
@@ -21,7 +21,7 @@ package com.github.fge.jsonschema.processors.validation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jsonschema.keyword.digest.Digester;
 import com.google.common.base.Equivalence;
 import com.google.common.collect.Lists;
@@ -37,7 +37,7 @@ import static org.testng.Assert.*;
 public final class ObjectSchemaDigesterTest
 {
     private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+        = JsonNumEquivalence.getInstance();
 
     private final Digester digester = ObjectSchemaDigester.getInstance();
     private final JsonNode testNode;


### PR DESCRIPTION
* Add missing project dependency on jackson-coreutils, moving it to be jackson-coreutils-equivalence, and converting references to JsonNumEquivalence.
* Updated to json-schema-core 1.2.14-SNAPSHOT.
* Updated jackson-databind javadoc link versions.