### PR TITLE
Migrate off deprecated mockito API

### DIFF
--- a/src/test/java/com/github/fge/jsonschema/format/AbstractFormatAttributeTest.java
+++ b/src/test/java/com/github/fge/jsonschema/format/AbstractFormatAttributeTest.java
@@ -125,7 +125,7 @@ public abstract class AbstractFormatAttributeTest
         attribute.validate(report, BUNDLE, data);
 
         if (valid) {
-            verifyZeroInteractions(report);
+            verifyNoMoreInteractions(report);
             return;
         }
 

--- a/src/test/java/com/github/fge/jsonschema/processors/format/FormatProcessorTest.java
+++ b/src/test/java/com/github/fge/jsonschema/processors/format/FormatProcessorTest.java
@@ -98,7 +98,7 @@ public final class FormatProcessorTest
 
         assertTrue(Lists.newArrayList(out).isEmpty());
 
-        verifyZeroInteractions(report);
+        verifyNoMoreInteractions(report);
     }
 
     @Test


### PR DESCRIPTION
`org.mockito.Mockito#verifyZeroInteractions` is a deprecated alias of
`verifyNoMoreInteractions`, which is being removed in the next version
of Mockito:
https://github.com/mockito/mockito/commit/caf35b24e2764df0498469526ecb3e7ec68a0430