### PR TITLE
Update InstanceValidator.java

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/processors/validation/InstanceValidator.java
+++ b/src/main/java/com/github/fge/jsonschema/processors/validation/InstanceValidator.java
@@ -175,10 +175,10 @@ final class InstanceValidator
         final ArraySchemaSelector selector = new ArraySchemaSelector(digest);
 
         final int size = node.size();
-
+        if(size=0){throws ProcessingException}
         FullData data;
         JsonTree newInstance;
-
+        
         for (int index = 0; index < size; index++) {
             newInstance = instance.append(JsonPointer.of(index));
             data = input.withInstance(newInstance);


### PR DESCRIPTION
针对Array类型数据，如果required有该类型字段，并且instance里关于这个array类型字段为[]，会通过schema校验，显然不合理。