### PR TITLE
Currently json schema validator is using com.sun.mail which depends on Java Mail API 1.6.2 and has vulnerabilities , should use jakarta mail instead.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile(group: "com.github.java-json-tools", name: "jackson-coreutils-equivalence", version: "1.0");
     compile(group: "com.github.java-json-tools", name: "json-schema-core", version: "1.2.14");
     // FIXME: 1.6.4 exists, but has different license (EDL 1.0, EPL 2.0). Can update?
-    compile(group: "com.sun.mail", name: "mailapi", version: "1.6.2");
+    compile(group: "jakarta.mail", name: "jakarta.mail-api", version: "2.1.2");
     compile(group: "joda-time", name: "joda-time", version: "2.10.5");
     compile(group: "com.googlecode.libphonenumber", name: "libphonenumber", version: "8.11.1");
     compile(group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2");

--- a/src/main/java/com/github/fge/jsonschema/format/common/EmailAttribute.java
+++ b/src/main/java/com/github/fge/jsonschema/format/common/EmailAttribute.java
@@ -27,8 +27,8 @@ import com.github.fge.jsonschema.format.FormatAttribute;
 import com.github.fge.jsonschema.processors.data.FullData;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 
 /**
  * Validator for the {@code email} format attribute.


### PR DESCRIPTION
Json shcema validator is using internally AddressException and InternetAddress for mail field validation from javax.mail.internet package which has dependency on Java Mail API (https://mvnrepository.com/artifact/com.sun.mail/javax.mail/1.6.2) and this version has the vulnerabilities.

If you see this has been moved to a new artifact https://mvnrepository.com/artifact/com.sun.mail/jakarta.mail which has more latest version and does not have any vulnerabilities.

We should also use the same in this repo. This PR has been raised for the same changes.